### PR TITLE
Added clickable logo

### DIFF
--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -28,6 +28,11 @@
   color: #fff;
 }
 
+a.titlelink:hover {
+  text-decoration: none;
+  cursor: pointer;
+}
+
 .title .find {
   color: #00a6fb;
 }

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -14,10 +14,10 @@ function Sidebar() {
             style={{ color: "#ffffff" }}
           />
         </div>
-        <div className="title">
+        <a href="https://dev-find.vercel.app/" className="titlelink"><div className="title">
           <p className="dev">dev</p>
           <p className="find">Find</p>
-        </div>
+        </div></a>
       </div>
       <div className="headline">
         Discover and Connect with Skilled Developers.


### PR DESCRIPTION
## Description

Made devFind paragraph logo clickable

## Related Issues

Fixed Issue #207 

## Changes Proposed

Included hyperlink tag to make the devFind paragraph logo clickable. I have also made this specific link not underlined on hover.

Hyperlink tag added here in .jsx file:

<a href="https://dev-find.vercel.app/" className="titlelink"><div className="title">
          <p className="dev">dev</p>
          <p className="find">Find</p>
        </div></a>

css added to the specific hyperlink tag added here:

a.titlelink:hover {
  text-decoration: none;
  cursor: pointer;
}

## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

## Note to reviewers

Please let me know if there are any issues, concerns or anything that needs modification.
Thanks