### PR TITLE
Fixed the social media Icons issue 

### DIFF
--- a/src/components/Profile/Profile.css
+++ b/src/components/Profile/Profile.css
@@ -1,4 +1,5 @@
 @import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css);
+
 .profile-container {
   margin-left: 20rem;
   padding: 0rem 1.5rem;
@@ -121,12 +122,14 @@
   list-style: none;
   margin: 0;
 }
+
 .social-icons li {
   display: inline-block;
   margin: 0;
   position: relative;
   font-size: 1.2em;
 }
+
 .social-icons i {
   color: #fff;
   position: absolute;
@@ -144,13 +147,15 @@
   height: 50px;
   border-radius: 15%;
   display: block;
-  background: linear-gradient(45deg, #195c6c,#2727ff);
+  background: linear-gradient(45deg, #195c6c, #2727ff);
   transition: all 265ms ease-out;
 }
+
 .social-icons a:hover:before {
   transform: scale(0);
   transition: all 265ms ease-in;
 }
+
 .social-icons a:hover i {
   transform: scale(2.25);
   -ms-transform: scale(2.25);
@@ -161,4 +166,11 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   transition: all 265ms ease-in;
+}
+
+@media only screen and (max-width: 478px) {
+  .social-icons i{
+    top: 19px;
+    left: 19.75px;
+  }
 }


### PR DESCRIPTION
## Description

I have added a media query for device widths <= 478 px to align social media Icons in center to there divs.
Issue: #231 


## Changes Proposed
This is the code which I added to profile.css file
`@media only screen and (max-width: 478px) {
  .social-icons i{
    top: 19px;
    left: 19.75px;
  }
}`

## Checklist
- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [ ] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://github.com/shyamtawli/devFind/assets/89456039/4daa9bae-f164-4a57-bf66-a33be57ef2f9)
![image](https://github.com/shyamtawli/devFind/assets/89456039/561e7624-5223-4972-8052-8a9451272b17)
![image](https://github.com/shyamtawli/devFind/assets/89456039/35d351ce-8aee-4232-9a9d-63c62f801536)
