### PR TITLE
changed URL of add your profile to automatically scroll to Add profile section in markdown

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -19,7 +19,7 @@ function Sidebar() {
       </div>
       <div className="headline">Discover and Connect with Skilled Developers.</div>
       <div className="description">
-        <a href="https://github.com/shyamtawli/devFind" target="_blank" rel="noreferrer">
+        <a href=" https://github.com/shyamtawli/devFind#how-to-add-your-profile-" target="_blank" rel="noreferrer">
           Add your profile?
         </a>
       </div>


### PR DESCRIPTION
## Description
when Add your profile link is clicked on website, it should automatically scroll to the Add your profile section.

## Related Issues
#287 

## Changes Proposed
- changed the URL of the Add your profile
![image](https://github.com/shyamtawli/devFind/assets/54446909/d5aa5f1c-01c0-4810-ad7e-e0c47b311a32)


## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [ ] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://github.com/shyamtawli/devFind/assets/54446909/132a5194-ebe3-444d-a83e-bd1a83c675a4)

## Note to reviewers
- This small feature will auto scroll for the users, so they don't have to navigate to the section.