### PR TITLE
fix: repository name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To contribute to devFind, you will need to have Node.js and Git installed on you
 
 Once you have installed these dependencies, you can clone the devFind repository to your local machine by running the following command in your terminal:
 
-    git clone https://github.com/devFind-io/devFind.git
+    git clone https://github.com/shyamtawli/devFind.git
 
 ## **Install `pnpm`**
 


### PR DESCRIPTION
changes in [CONTRIBUTING.md](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md)

from

    git clone https://github.com/devFind-io/devFind.git

to 

    git clone https://github.com/shyamtawli/devFind.git
