### PR TITLE
Fixing issue #405 : Showing border while hovering social media icons

### DIFF
--- a/src/components/Profile/Profile.css
+++ b/src/components/Profile/Profile.css
@@ -155,6 +155,7 @@
 .social-icons a:hover:before {
   transform: scale(0);
   transition: all 265ms ease-in;
+  -webkit-tap-highlight-color: transparent; /* Add the WebKit-specific property to remove the border in safari browser*/
 }
 
 .social-icons a:hover i {
@@ -173,5 +174,12 @@
   .social-icons i {
     top: 19px;
     left: 19.75px;
+  }
+}
+
+/* Add this CSS to specifically target Safari */
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  .social-icons i {
+    -webkit-backface-visibility : hidden;
   }
 }


### PR DESCRIPTION
## Description

Resolve the bug that causes an unwanted border to appear when hovering over social media icons in the Safari browser.

## Related Issues

Fixes : #405 


## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

- Before 

https://github.com/shyamtawli/devFind/assets/72021210/2cbc0a18-b3f6-4a1b-82a5-a878fdd85fae

- After
 

https://github.com/shyamtawli/devFind/assets/72021210/04934c36-0035-48b9-80ff-f9223b390dff



## Note to reviewers
