### PR TITLE
Fixed Centering the ' No Result Found ' on search

### DIFF
--- a/src/components/NoResultFound/NoResultFound.css
+++ b/src/components/NoResultFound/NoResultFound.css
@@ -10,6 +10,7 @@
   padding: 1rem;
   height: auto;
   color: var(--text-color);
+  text-align: center;
 }
 
 .no-result-card .top-container {


### PR DESCRIPTION
## Description

Fixed Fixed Centering the ' No Result Found ' on search 

Closes #505 

## Changes Proposed
Added text-align: center property to make no result found to the center
[Describe the changes you've made in detail. Be specific and include any relevant code snippets.]

## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://github.com/shyamtawli/devFind/assets/104289350/cd953a04-0681-46c6-a273-c7919a62c41b)

## Note to reviewers
