### PR TITLE
[FIX]: Comment out instructions in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 ## Description
 
-[Include a brief description of the changes you've made]
+<!--- Include a brief description of the changes you've made --->
 
 ## Related Issues
 
-[Include any related issues or pull requests that this PR addresses or is related to. Use GitHub's shorthand syntax to link to them, like #1234.]
+<!--- Include any related issues or pull requests that this PR addresses or is related to. Use GitHub's shorthand syntax to link to them, like #1234. --->
 
 ## Changes Proposed
 
-[Describe the changes you've made in detail. Be specific and include any relevant code snippets.]
+<!--- Describe the changes you've made in detail. Be specific and include any relevant code snippets. --->
 
 ## Checklist
 


### PR DESCRIPTION
## Description

Changes the pr template to have instructional lines be commented out so that they don't show up in the markdown preview.

## Related Issues

Does not close any issue

## Changes Proposed

In the PR template there are these instructional lines that tell the user how to create a better pr, but it's not necessary to have those lines show up when that markdown is previewed.

## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
### Before :

![Screenshot from 2023-10-16 19-38-19](https://github.com/shyamtawli/devFind/assets/77718741/59b21557-d4d5-4b79-a064-ad56f7cbf5f1)

#### The instructional lines are showing up in the markdown preview:

![Screenshot from 2023-10-16 19-37-57](https://github.com/shyamtawli/devFind/assets/77718741/3cb32f12-9cee-4be7-8dca-ffd5173ea47c)


### After:

![Screenshot from 2023-10-16 19-39-01](https://github.com/shyamtawli/devFind/assets/77718741/4b9bef08-da8d-47df-a72c-6ebf3299bb76)

#### Those lines are now not showing in the preview but are still there for the user to see and read:

![Screenshot from 2023-10-16 19-39-16](https://github.com/shyamtawli/devFind/assets/77718741/a789d7e2-49a3-4f30-8708-c0edc249c7d5)

## Note to reviewers
