### PR TITLE
Fix: #614 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -126,12 +126,14 @@ function App() {
       {currentUrl === '/' ? (
         <>
           {profiles.length === 0 && searching ? <NoResultFound /> : renderProfiles()}
-          <Pagination
-            currentPage={currentPage}
-            totalPages={Math.ceil((searching ? profiles.length : shuffledProfiles.length) / recordsPerPage)}
-            onNextPage={handleNextPage}
-            onPrevPage={handlePrevPage}
-          />
+          {profiles.length > 0 && (
+              <Pagination
+                  currentPage={currentPage}
+                  totalPages={Math.ceil((searching ? profiles.length : shuffledProfiles.length) / recordsPerPage)}
+                  onNextPage={handleNextPage}
+                  onPrevPage={handlePrevPage}
+              />
+          )}
         </>
       ) : (
         <ErrorPage />


### PR DESCRIPTION
## Description

Fixes Issue #614 

<!--- Include a brief description of the changes you've made --->

Bug description : I found a BUG 🐞 in the devFind project. When performing a search, if the search result yields no developer profile, the Previous and Next buttons are displayed. This behaviour seems incorrect, as there's no need for pagination when there's only no result.

## Related Issues

#614 
<!--- Include any related issues or pull requests that this PR addresses or is related to. Use GitHub's shorthand syntax to link to them, like #1234. --->

## Changes Proposed

Bug fix implementation : 
Modified one line in App.js to conditionally render the Pagination Component. So when, the number of profiles that are found for any particular keyword search are greater than 0, then only the Pagination Component will be rendered. 
<!--- Describe the changes you've made in detail. Be specific and include any relevant code snippets. --->

![fix2](https://github.com/shyamtawli/devFind/assets/95047201/6c0e4e58-208a-49ac-a6cd-f90f7a0ad9ee)


## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.
