### PR TITLE
Added Error Case Where Profile Picture Is Absent

### DIFF
--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -33,9 +33,9 @@ function Profile({ data }) {
     return (
       <div className="profile-card">
         <div className="top-container">
-          <div className="profile-photo">
+          {data.avatar && <div className="profile-photo">
             <img src={data.avatar} alt="User logo" />
-          </div>
+          </div>}
           <div className="profile-details">
             <h3>
               <a className="profile-name" href={data.portfolio} target="_blank" rel="noreferrer">


### PR DESCRIPTION
## Description

If profile picture is not present, unwanted text is displayed - see #728

## Related Issues

#728

## Changes Proposed

Render div and img blocks only if `data.avatar` is populated

## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

## Note to reviewers
