### PR TITLE
Increase search input's right padding & search icon's right margin

### DIFF
--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -55,7 +55,7 @@ function Search({ onSearch }) {
   return (
     <div className="relative flex items-center justify-end pb-6">
       <input
-        className="h-12 w-full rounded-md border-2 border-borderSecondary bg-primaryColor px-4 py-3 font-spaceMono text-base text-secondaryColor outline-none dark:border-borderColor dark:bg-secondaryColor dark:text-white"
+        className="h-12 w-full rounded-md border-2 border-borderSecondary bg-primaryColor px-4 py-3 pr-12 font-spaceMono text-base text-secondaryColor outline-none dark:border-borderColor dark:bg-secondaryColor dark:text-white"
         ref={searchInput}
         type="text"
         onChange={handleInputChange}
@@ -65,7 +65,7 @@ function Search({ onSearch }) {
       />
       <FontAwesomeIcon
         onClick={handleSearchButtonClick}
-        className="absolute mr-2.5 cursor-pointer text-xl hover:text-textSecondary dark:text-white dark:hover:text-textSecondary"
+        className="absolute mr-4 cursor-pointer text-xl hover:text-textSecondary dark:text-white dark:hover:text-textSecondary"
         icon={faMagnifyingGlass}
       />
       {searchValue && (


### PR DESCRIPTION
## Description

I have introduced changes related to search input's padding as well as to search icon's margin.

## Related Issues

No related issues.

## Changes Proposed

Right now on small screens there can be an issue of search input's placeholder text being displayed under the search icon.

![Screenshot from 2024-02-04 21-48-58](https://github.com/shyamtawli/devFind/assets/88098862/3c4d6af1-d6ad-420d-a1ff-22f0567f4229)

On the screenshot above we can also see that search bar's icon is not consistent with padding of its parent element (input). I've changed search icon's right margin value from `2.5` to `4`, so both the left side of input and the right one look the same in terms of their padding.

In order to fix the above-mentioned issue related to placeholder text being displayer under the search icon the right  padding of input element was changed including right margin of the search icon, search icon's width and the same padding from it to the left side which resulted in `pr-12`.

![Screenshot from 2024-02-04 21-59-16](https://github.com/shyamtawli/devFind/assets/88098862/82593d7a-06f0-4fe3-9777-f4677688f188)

## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.