### PR TITLE
Use stable keys for profile lists

### DIFF
--- a/components/Profile.jsx
+++ b/components/Profile.jsx
@@ -63,11 +63,11 @@ function Card({ data }) {
             ref={cardRef}
           >
             {data.skills &&
-              data.skills.map((skill, index) => {
+              data.skills.map((skill) => {
                 return (
                   <div
                     className="inline h-auto cursor-default whitespace-nowrap rounded-md bg-secondaryColor px-2 py-1 text-[9px] text-white sm:text-sm md:h-[30px]"
-                    key={index}
+                    key={skill}
                   >
                     {skill}
                   </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -132,8 +132,8 @@ function App() {
       );
     }
     const paginatedData = getPaginatedData();
-    return paginatedData.map((currentRecord, index) => (
-      <Profile data={currentRecord} key={index} />
+    return paginatedData.map((currentRecord) => (
+      <Profile data={currentRecord} key={currentRecord.social.GitHub} />
     ));
   };
 


### PR DESCRIPTION
Summary:
- Use stable data-derived keys for rendered profiles and skill badges instead of array indexes.
- Keeps React reconciliation stable when profile or skill ordering changes.

Test plan:
- `git diff --check`
- Attempted `npm ci --ignore-scripts --no-audit`, but npm is unavailable in this Codex shell.

Closes #1260