### PR TITLE
fix: use stable profile keys

### DIFF
--- a/components/Profile.jsx
+++ b/components/Profile.jsx
@@ -63,11 +63,11 @@ function Card({ data }) {
             ref={cardRef}
           >
             {data.skills &&
-              data.skills.map((skill, index) => {
+              data.skills.map((skill) => {
                 return (
                   <div
                     className="inline h-auto cursor-default whitespace-nowrap rounded-md bg-secondaryColor px-2 py-1 text-[9px] text-white sm:text-sm md:h-[30px]"
-                    key={index}
+                    key={skill}
                   >
                     {skill}
                   </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -119,21 +119,24 @@ function App() {
     return data.slice(startIndex, endIndex);
   };
 
+  const getGitHubUsername = (profile) => {
+    const githubUrl = profile.social?.GitHub;
+    return githubUrl?.split("/").filter(Boolean).pop() || profile.name;
+  };
+
   const renderProfiles = () => {
     if (loadingProfiles) {
       return (
         <>
-          {Array(5)
-            .fill("profile-skeleton")
-            .map((item, index) => (
-              <ProfileSkeleton key={index} />
-            ))}
+          {Array.from({ length: 5 }, (_, skeletonNumber) => (
+            <ProfileSkeleton key={`profile-skeleton-${skeletonNumber}`} />
+          ))}
         </>
       );
     }
     const paginatedData = getPaginatedData();
-    return paginatedData.map((currentRecord, index) => (
-      <Profile data={currentRecord} key={index} />
+    return paginatedData.map((currentRecord) => (
+      <Profile data={currentRecord} key={getGitHubUsername(currentRecord)} />
     ));
   };
 


### PR DESCRIPTION
## Description

This PR replaces unstable array-index React keys with stable values for profile cards and skill chips.

## Related Issues

Closes #1260

## Changes Proposed

- Updated `pages/index.js` so rendered `<Profile />` components are keyed by the profile's GitHub username instead of the array index.
- Updated loading skeleton keys to use deterministic skeleton IDs instead of `key={index}`.
- Updated `components/Profile.jsx` so skill chips are keyed by the skill string instead of the array index.

## Checklist

- [x] I have read and followed the [Contribution Guidelines](https://github.com/shyamtawli/devFind/blob/master/CONTRIBUTING.md).
- [x] All new and existing tests passed.
- [x] I have updated the documentation to reflect the changes I've made.
- [x] My code follows the code style of this project.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

No UI appearance changes.

## Note to reviewers

Tested with `npm.cmd run lint` and `npm.cmd run build`. Both passed with existing project warnings unrelated to this change.
