### PR TITLE
fix: replace <img> with next/image and fix avatar alt text

### DIFF
--- a/components/Profile.jsx
+++ b/components/Profile.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import Image from "next/image";
 import { FaGithub, FaLinkedin } from "react-icons/fa";
 import { FaXTwitter, FaLocationDot } from "react-icons/fa6";
 
@@ -36,9 +37,11 @@ function Card({ data }) {
     <div className="mb-6 h-auto rounded-lg bg-white p-4 shadow dark:bg-textPrimary">
       <div className="relative flex gap-4">
         <div className="h-24 w-24 flex-shrink-0">
-          <img
+          <Image
             src={imageSrc}
-            alt="User logo"
+            alt={`${data.name}'s avatar`}
+            width={96}
+            height={96}
             onError={() => setImageSrc('/defaultAvatar.webp')}
             className="h-full w-full rounded-full"
           />

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      { hostname: 'avatars.githubusercontent.com' },
+      { hostname: 'github.com' },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Fixes #1261

## Changes

- **`components/Profile.jsx`**: Replaced `<img>` with `next/image` (`Image` component), set explicit `width={96}` and `height={96}`, and updated `alt` from the generic `"User logo"` to the descriptive `` `${data.name}'s avatar` ``. The existing `onError` fallback to `/defaultAvatar.webp` is preserved.
- **`next.config.mjs`**: Added `images.remotePatterns` for `avatars.githubusercontent.com` and `github.com` so Next.js allows GitHub avatar URLs.

## Acceptance criteria

- [x] `<img>` replaced by `<Image>` with explicit width/height
- [x] `alt` is now `"<Name>'s avatar"` — screen reader friendly
- [x] Fallback to `/defaultAvatar.webp` still works via `onError`
- [x] GitHub avatar hosts whitelisted in `next.config.mjs`